### PR TITLE
wył. indeksowania subdomen

### DIFF
--- a/source/robots.blade.txt
+++ b/source/robots.blade.txt
@@ -1,4 +1,8 @@
 User-agent: *
+@if(getenv('BRANCH') === 'main')
 Allow: /
 
 Sitemap: {{ $page->baseUrl }}/sitemap.xml
+@else
+Disallow: /
+@endif


### PR DESCRIPTION
Teraz powinny przestać się indeksować w wyszukwarkach podglądy na subdomenach (dev.tranzycja.pl, test.tranzycja.pl itp)